### PR TITLE
Add additional methods for API use-cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,18 @@ module.exports = {
             return obj;
         }
         return new CoverageMap(obj);
+    },
+    /**
+     * creates a FileCoverage object
+     * @param {Object} obj optional - an argument with the same semantics
+     *  as the one passed to the FileCoverage constructor.
+     * @returns {FileCoverage}
+     */
+    createFileCoverage: function (obj) {
+        if (obj && obj instanceof FileCoverage) {
+            return obj;
+        }
+        return new FileCoverage(obj);
     }
 };
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -301,6 +301,22 @@ FileCoverage.prototype.computeBranchTotals = function () {
     return ret;
 };
 
+FileCoverage.prototype.resetHits = function () {
+    var statements = this.s,
+        functions = this.f,
+        branches = this.b;
+    Object.keys(statements).forEach(function (s) {
+        statements[s] = 0;
+    });
+    Object.keys(functions).forEach(function (f) {
+        functions[f] = 0;
+    });
+    Object.keys(branches).forEach(function (b) {
+        var hits = branches[b];
+        branches[b] = hits.map(function () { return 0; });
+    });
+};
+
 /**
  * returns a CoverageSummary for this file coverage object
  * @returns {CoverageSummary}

--- a/test/file.test.js
+++ b/test/file.test.js
@@ -231,6 +231,54 @@ describe('base coverage', function () {
         assert.equal(c1.b[1][1], 2);
     });
 
+    it('resets hits when requested', function () {
+        var loc = function (sl, sc, el, ec) {
+                return {
+                    start: {line: sl, column: sc},
+                    end: {line: el, column: ec}
+                };
+            },
+            fc = new FileCoverage({
+                path: '/path/to/file',
+                statementMap: {
+                    1: loc(1, 1, 1, 100),
+                    2: loc(2, 1, 2, 50),
+                    3: loc(2, 51, 2, 100),
+                    4: loc(2, 101, 3, 100)
+                },
+                fnMap: {
+                    1: {
+                        name: 'foobar',
+                        line: 1,
+                        loc: loc(1, 1, 1, 50)
+                    }
+                },
+                branchMap: {
+                    1: {
+                        type: 'if',
+                        line: 2,
+                        locations: [ loc(2,1,2,20), loc(2,50, 2, 100) ]
+                    }
+                },
+                s: {
+                    1: 2,
+                    2: 3,
+                    3: 1,
+                    4: 0
+                },
+                f: {
+                    1: 54
+                },
+                b: {
+                    1: [ 1, 50 ]
+                }
+            });
+        fc.resetHits();
+        assert.deepEqual({1:0, 2:0, 3:0, 4:0}, fc.s);
+        assert.deepEqual({1:0}, fc.f);
+        assert.deepEqual({1: [0,0]}, fc.b);
+    });
+
     it('returns uncovered lines', function () {
         var c = new FileCoverage({
             path: '/path/to/file',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,4 +23,11 @@ describe('external interface', function () {
         fc2 = index.createCoverageMap(fc);
         assert.ok(fc2 === fc);
     });
+    it('allows file coverage creation', function () {
+        var fc = index.createFileCoverage('/path/to/foo.js'),
+            fc2;
+        assert.ok(fc instanceof index.classes.FileCoverage);
+        fc2 = index.createFileCoverage(fc);
+        assert.ok(fc2 === fc);
+    });
 });


### PR DESCRIPTION
- Ability to reset the hit count for a file coverage object
- Expose creation of file coverage objects
