### PR TITLE
Add possibility to filter coveragemaps

### DIFF
--- a/lib/coverage-map.js
+++ b/lib/coverage-map.js
@@ -58,6 +58,19 @@ CoverageMap.prototype.merge = function (obj) {
     });
 };
 /**
+ * filter the coveragemap based on the callback provided
+ * @param {Function (filename)} callback - Returns true if the should be
+ *  include in the coveragemap. False if it should be removed.
+ */
+CoverageMap.prototype.filter = function (callback) {
+     var that = this;
+     Object.keys(that.data).forEach(function (k) {
+         if (!callback(k)) {
+             delete that.data[k];
+         }
+     });
+}
+/**
  * returns a JSON-serializable POJO for this coverage map
  * @returns {Object}
  */


### PR DESCRIPTION
To be able to filter not only the files being instrumented, but also in the reports it is required to filter the coveragemaps.

E.G. Instrument and write to the cache directory using `nyc --silent ava` and later create specific report using e.g. `nyc report --include '**/bin/*.js` (ignoring all other files located in e.g. **/lib/**

In my specific this is required because my files are precompiled using rollup. This includes also files from external libraries in the resulting files. These files get tested (other the tests will fail due to import statements). However nyc will only exclude files actually present. It doesn't perform this action based on the  sourcemaps. Therefor I filter the report itself.